### PR TITLE
Apostrophes (') must be escaped in xml.

### DIFF
--- a/src/rename-app.js
+++ b/src/rename-app.js
@@ -38,7 +38,7 @@ module.exports = function (context) {
                 if (string.$.name === 'app_name') {
 
                     console.log('Setting App Name: ', name);
-                    string._ = name;
+                    string._ = name.replace(/'/g, "\\'");
                 }
             });
 


### PR DESCRIPTION
This is needed if we want to put apostrophes (') in the application name.
