### PR TITLE
Fix issues with cordova@7 by calling the after prepare hook on android only

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -12,12 +12,12 @@
     </engines>
 
     <preference name="APP_NAME"/>
-    <hook type="after_prepare" src="src/rename-app.js"/>
 
     <platform name="android">
         <config-file target="config.xml" parent="/*">
             <preference name="AppName" value="$APP_NAME"/>
         </config-file>
+        <hook type="after_prepare" src="src/rename-app.js"/>
     </platform>
 
     <platform name="ios">

--- a/src/rename-app.js
+++ b/src/rename-app.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var fs = require('fs');
-var path = require("path");
+var path = require('path');
 var xml2js = require('xml2js');
 var parser = new xml2js.Parser();
 var builder = new xml2js.Builder({
@@ -32,6 +32,10 @@ module.exports = function (context) {
     if (name) {
         stringsXml = fs.readFileSync(stringsPath, 'UTF-8');
         parser.parseString(stringsXml, function (err, data) {
+            if(!data || !data.resources) {
+                console.error('Error parsing android strings.xml.');
+                return;
+            }
 
             data.resources.string.forEach(function (string) {
 


### PR DESCRIPTION
I had issues with this plugin and cordova 7.
To fix it, i changed to code to run the hook for the after_prepare.js on android only (it deals with androids strings.xml after all). Additionally, I checked if the data and data resources is defined after reading the strings.xml to provide more helpful error messages.